### PR TITLE
Fixing bug with OfferClassifiedPackages put

### DIFF
--- a/src/Resource/Sale/OfferClassifiedsPackages.php
+++ b/src/Resource/Sale/OfferClassifiedsPackages.php
@@ -21,6 +21,6 @@ class OfferClassifiedsPackages extends AbstractResource
      */
     public function put(string $offerId, array $body): ResponseInterface
     {
-        return $this->apiPost("/sale/offer-classifieds-packages/{$offerId}", $body);
+        return $this->apiPut("/sale/offer-classifieds-packages/{$offerId}", $body);
     }
 }


### PR DESCRIPTION
Metoda put wywoływała apiPost co powodowało zwrot NotAllowedException przez allegro