### PR TITLE
Rozszerzenie metody getPost o możliwość dodania Accept header

### DIFF
--- a/src/Enum/ContentType.php
+++ b/src/Enum/ContentType.php
@@ -7,10 +7,11 @@ namespace Imper86\PhpAllegroApi\Enum;
 final class ContentType
 {
     public const X_WWW_FORM_URLENCODED = 'application/x-www-form-urlencoded';
-    public const JSON = 'application/json';
-    public const VND_PUBLIC_V1 = 'application/vnd.allegro.public.v1+json';
-    public const VND_PUBLIC_V2 = 'application/vnd.allegro.public.v2+json';
-    public const VND_BETA_V1 = 'application/vnd.allegro.beta.v1+json';
-    public const VND_BETA_V2 = 'application/vnd.allegro.beta.v2+json';
-    public const VND_BETA_V3 = 'application/vnd.allegro.beta.v3+json';
+    public const JSON                  = 'application/json';
+    public const VND_PUBLIC_V1         = 'application/vnd.allegro.public.v1+json';
+    public const VND_PUBLIC_V2         = 'application/vnd.allegro.public.v2+json';
+    public const VND_BETA_V1           = 'application/vnd.allegro.beta.v1+json';
+    public const VND_BETA_V2           = 'application/vnd.allegro.beta.v2+json';
+    public const VND_BETA_V3           = 'application/vnd.allegro.beta.v3+json';
+    public const OCTET_STREAM          = 'application/octet-stream';
 }

--- a/src/Resource/ShipmentManagement.php
+++ b/src/Resource/ShipmentManagement.php
@@ -20,9 +20,9 @@ use Imper86\PhpAllegroApi\Resource\ShipmentManagement\PickupProposals;
  * @method ShipmentCreateCommands shipmentCreateCommands()
  * @method ShipmentCancelCommands shipmentCancelCommands()
  * @method PickupCreateCommands pickupCreateCommands()
- * @method Shipment shipments()
- * @method Label labels()
- * @method Protocol protocols()
+ * @method Shipment shipment()
+ * @method Label label()
+ * @method Protocol protocol()
  * @method PickupProposals pickupProposals()
  *
  */

--- a/src/Resource/ShipmentManagement/Label.php
+++ b/src/Resource/ShipmentManagement/Label.php
@@ -2,6 +2,7 @@
 
 namespace Imper86\PhpAllegroApi\Resource\ShipmentManagement;
 
+use Imper86\PhpAllegroApi\Enum\ContentType;
 use Imper86\PhpAllegroApi\Resource\AbstractResource;
 use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -19,6 +20,6 @@ class Label extends AbstractResource
      */
     public function post(array $body): ResponseInterface
     {
-        return $this->apiPost('/shipment-management/label', $body);
+        return $this->apiPost('/shipment-management/label', $body,ContentType::VND_PUBLIC_V1, ContentType::OCTET_STREAM);
     }
 }


### PR DESCRIPTION
Zmiany:

AbstractResource:
Zmiany w metodzie apiPost, aby poprawnie można było użyć innego nagłówka Accept inny niż content type

Label:
Zastosowanie zmian z Abstract resource aby umożliwić poprawnie wywołanie zapytania.

ContentType:
Dodanie nowej wartości. 

Poprawki:

ShipmentManagement:
Poprawiono deklaracje metod